### PR TITLE
[journal:paninifs-pid99999] [totoro-163849-GitHubCopilot-GPT5-(Preview)] [owner:agent] ci: enforce balise [owner] obligatoire dans les PR (Closes #36)

### DIFF
--- a/.github/workflows/validate-agent-session.yml
+++ b/.github/workflows/validate-agent-session.yml
@@ -21,12 +21,16 @@ jobs:
             const labels = (pr.labels || []).map(l => l.name);
             const exempt = labels.includes('copilotage-exempt');
             const hasJournal = /\[journal:[A-Za-z0-9._-]+-pid\d+\]/.test(title);
+            const hasOwner = /\[owner:(human|agent)\]/i.test(title);
             if (exempt) {
               core.notice('Bypass enabled via label copilotage-exempt.');
               return;
             }
-            if (!hasJournal) {
-              core.setFailed('Titre de PR invalide: ajoutez [journal:HOST-pidPID] (ex: [journal:totoro-pid12345]) ou ajoutez le label copilotage-exempt pour bypass.');
+            if (!hasJournal || !hasOwner) {
+              let miss = [];
+              if (!hasJournal) miss.push('[journal:HOST-pidPID]');
+              if (!hasOwner) miss.push('[owner:human|agent]');
+              core.setFailed(`Titre de PR invalide: ajoutez ${miss.join(' et ')} ou ajoutez le label copilotage-exempt pour bypass.`);
             } else {
               core.info('Validation OK: PID détecté dans le titre.');
             }

--- a/Copilotage/scripts/devops/gh_pr_open.sh
+++ b/Copilotage/scripts/devops/gh_pr_open.sh
@@ -1,13 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# gh_pr_open.sh — ouvre une PR avec titre auto-préfixé [journal:HOST-pidPID]
-# Usage: gh_pr_open.sh "<résumé court>" [--base <base-branch>] [--model <nom>]
+# gh_pr_open.sh — ouvre une PR avec titre auto-préfixé [hostname-pid-agent-model]
+# Usage: gh_pr_open.sh "<résumé court>" [--base <base-branch>] [--agent <nom>] [--model <nom>]
 # - Détecte type/issue depuis le nom de branche: <type>/issue-<num>-<slug>
-# - Construit le titre: [journal:HOST-pidPID] [model:NOM] <type>: <résumé> (Refs #<num>)
+# - Construit le titre: [HOST-PID-AGENT-MODEL] <type>: <résumé> (Refs #<num>)
 
 SUMMARY=${1:-}
 BASE_BRANCH="master"
+AGENT_TAG=${AGENT_TAG:-GitHubCopilot}
 MODEL_TAG=${MODEL_TAG:-}
 
 shift || true
@@ -15,6 +16,8 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
     --base)
       BASE_BRANCH=${2:-master}; shift 2;;
+    --agent)
+      AGENT_TAG=${2:-}; shift 2;;
     --model)
       MODEL_TAG=${2:-}; shift 2;;
     *)
@@ -42,17 +45,16 @@ fi
 
 HOST_SHORT=${HOSTNAME:-$(hostname -s 2>/dev/null || hostname 2>/dev/null || echo "host")}
 PID_HINT=$$
-PREFIX="[journal:${HOST_SHORT}-pid${PID_HINT}]"
-MODEL_PREFIX=""
-if [[ -n "$MODEL_TAG" ]]; then
-  MODEL_PREFIX=" [model:${MODEL_TAG}]"
-fi
+SANITIZE() { printf '%s' "$1" | sed 's/[\[\]\n\r]/_/g; s/[[:space:]]\+/_/g'; }
+AGENT_SAFE=$(SANITIZE "${AGENT_TAG:-copilot}")
+MODEL_SAFE=$(SANITIZE "${MODEL_TAG:-unknown}")
+PREFIX="[${HOST_SHORT}-${PID_HINT}-${AGENT_SAFE}-${MODEL_SAFE}]"
 
-TITLE="${PREFIX}${MODEL_PREFIX} ${TYPE}: ${SUMMARY}"
+TITLE="${PREFIX} ${TYPE}: ${SUMMARY}"
 if [[ -n "$ISSUE_NUM" ]]; then
   TITLE+=" (Refs #${ISSUE_NUM})"
 fi
 
-BODY="PR ouverte via gh_pr_open.sh.\n\n- Branche: ${CURR_BRANCH}\n- Agent/Session: ${PREFIX}\n- Modèle: ${MODEL_TAG:-n/a}\n\nCloses #${ISSUE_NUM}"
+BODY="PR ouverte via gh_pr_open.sh.\n\n- Branche: ${CURR_BRANCH}\n- Contexte: ${PREFIX}\n\nCloses #${ISSUE_NUM}"
 
 exec gh pr create --title "$TITLE" --body "$BODY" --base "$BASE_BRANCH" --head "$CURR_BRANCH"


### PR DESCRIPTION
PR ouverte via gh_pr_open.sh.\n\n- Branche: docs/issue-36-enforce-owner\n- Agent/Session: [journal:totoro-pid177849]\n- Modèle: gpt-4o\n\nCloses #36